### PR TITLE
Vacation time calc

### DIFF
--- a/src/main/java/com/sixshop/sixspace/vacation/domain/VacationLocalDateTime.java
+++ b/src/main/java/com/sixshop/sixspace/vacation/domain/VacationLocalDateTime.java
@@ -1,0 +1,74 @@
+package com.sixshop.sixspace.vacation.domain;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@ToString
+public class VacationLocalDateTime {
+
+    private static final int ONE_HOUR = 1;
+    private static final LocalTime GO_OFFICE_TIME = LocalTime.of(9, 0);
+    private static final LocalTime LEAVE_OFFICE_TIME = LocalTime.of(18, 0);
+
+    @Getter
+    private final LocalDateTime time;
+
+    private VacationLocalDateTime(LocalDateTime time) {
+        this.time = time;
+    }
+
+    public static VacationLocalDateTime of(LocalDate date, LocalTime time) {
+        return new VacationLocalDateTime(LocalDateTime.of(date, time));
+    }
+
+    public static VacationLocalDateTime of(LocalDateTime localDateTime) {
+        return VacationLocalDateTime.of(localDateTime.toLocalDate(), localDateTime.toLocalTime());
+    }
+
+    public VacationLocalDateTime plusHours(long hours) {
+        int remainingHour = getRemainingHour(hours);
+
+        if (remainingHour >= ONE_HOUR) {
+            return overTomorrow(remainingHour);
+        }
+        return inToday(hours);
+    }
+
+    private VacationLocalDateTime overTomorrow(long hours) {
+        LocalDate localDate = time.plusDays(1)
+            .toLocalDate();
+        LocalTime localTime = GO_OFFICE_TIME.plusHours(hours);
+
+        return VacationLocalDateTime.of(localDate, localTime);
+    }
+
+    private VacationLocalDateTime inToday(long hours) {
+        LocalDateTime localDateTime = time.plusHours(hours);
+        if (localDateTime.toLocalTime().isAfter(LEAVE_OFFICE_TIME)) {
+            localDateTime = localDateTime.minusMinutes(time.getMinute());
+        }
+
+        return new VacationLocalDateTime(localDateTime);
+    }
+
+    private int getRemainingHour(long hour) {
+        int plusHour = time.plusHours(hour).getHour(); // 사용 휴가 시간
+        int leaveHour = LEAVE_OFFICE_TIME.getHour(); // 퇴근시간
+
+        if (plusHour <= leaveHour) {
+            return 0;
+        }
+
+        if (plusHour - leaveHour < ONE_HOUR) {
+            return 0;
+        }
+
+        return plusHour - leaveHour;
+    }
+
+}

--- a/src/main/java/com/sixshop/sixspace/vacation/domain/VacationLocalDateTime.java
+++ b/src/main/java/com/sixshop/sixspace/vacation/domain/VacationLocalDateTime.java
@@ -11,6 +11,7 @@ import lombok.ToString;
 @ToString
 public class VacationLocalDateTime {
 
+    private static final int STANDARD_OF_MINUTE = 10;
     private static final int ONE_HOUR = 1;
     private static final LocalTime GO_OFFICE_TIME = LocalTime.of(9, 0);
     private static final LocalTime LEAVE_OFFICE_TIME = LocalTime.of(18, 0);
@@ -23,7 +24,7 @@ public class VacationLocalDateTime {
     }
 
     public static VacationLocalDateTime of(LocalDate date, LocalTime time) {
-        if ((time.getMinute() % 10) != 0) {
+        if ((time.getMinute() % STANDARD_OF_MINUTE) != 0) {
             throw new IllegalArgumentException("10분 단위로 설정 가능");
         }
 
@@ -35,7 +36,7 @@ public class VacationLocalDateTime {
         return VacationLocalDateTime.of(localDateTime.toLocalDate(), localDateTime.toLocalTime());
     }
 
-    public VacationLocalDateTime plusHours(long hours) {
+    public VacationLocalDateTime plusHours(int hours) {
         int remainingHour = getRemainingHour(hours);
 
         if (remainingHour >= ONE_HOUR) {
@@ -44,7 +45,7 @@ public class VacationLocalDateTime {
         return inToday(hours);
     }
 
-    private VacationLocalDateTime overTomorrow(long hours) {
+    private VacationLocalDateTime overTomorrow(int hours) {
         LocalDate localDate = time.plusDays(1)
             .toLocalDate();
         LocalTime localTime = GO_OFFICE_TIME.plusHours(hours);
@@ -52,7 +53,7 @@ public class VacationLocalDateTime {
         return VacationLocalDateTime.of(localDate, localTime);
     }
 
-    private VacationLocalDateTime inToday(long hours) {
+    private VacationLocalDateTime inToday(int hours) {
         LocalDateTime localDateTime = time.plusHours(hours);
         if (localDateTime.toLocalTime().isAfter(LEAVE_OFFICE_TIME)) {
             localDateTime = localDateTime.minusMinutes(time.getMinute());
@@ -61,7 +62,7 @@ public class VacationLocalDateTime {
         return new VacationLocalDateTime(localDateTime);
     }
 
-    private int getRemainingHour(long hour) {
+    private int getRemainingHour(int hour) {
         int plusHour = time.plusHours(hour).getHour(); // 사용 휴가 시간
         int leaveHour = LEAVE_OFFICE_TIME.getHour(); // 퇴근시간
 

--- a/src/main/java/com/sixshop/sixspace/vacation/domain/VacationLocalDateTime.java
+++ b/src/main/java/com/sixshop/sixspace/vacation/domain/VacationLocalDateTime.java
@@ -23,6 +23,11 @@ public class VacationLocalDateTime {
     }
 
     public static VacationLocalDateTime of(LocalDate date, LocalTime time) {
+        if ((time.getMinute() % 10) != 0) {
+            throw new IllegalArgumentException("10분 단위로 설정 가능");
+        }
+
+        time = time.withSecond(0);
         return new VacationLocalDateTime(LocalDateTime.of(date, time));
     }
 

--- a/src/test/java/com/sixshop/sixspace/vacation/domain/VacationLocalDateTimeTest.java
+++ b/src/test/java/com/sixshop/sixspace/vacation/domain/VacationLocalDateTimeTest.java
@@ -1,12 +1,15 @@
 package com.sixshop.sixspace.vacation.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class VacationLocalDateTimeTest {
 
@@ -39,6 +42,48 @@ class VacationLocalDateTimeTest {
         assertThat(target1)
             .isEqualTo(target2)
             .isEqualTo(target3);
+    }
+
+    @DisplayName("초 단위는 버린다")
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 5, 10, 20, 30, 40, 50, 59})
+    void of_second(int second) {
+        // given
+        LocalTime localTime = LocalTime.of(9, 10, second);
+        LocalTime compare = LocalTime.of(9, 10);
+
+        // when
+        VacationLocalDateTime target = VacationLocalDateTime.of(localDate, localTime);
+
+        // then
+        System.out.println(target.getTime());
+        System.out.println(compare);
+        assertThat(target.getTime().toLocalTime())
+            .isEqualTo(compare);
+    }
+
+    @DisplayName("10분 단위로 설정 가능 - 성공")
+    @ParameterizedTest
+    @ValueSource(ints = {0, 10, 20, 30, 40, 50})
+    void of_minute_success(int minute) {
+        // given
+        LocalTime localTime = LocalTime.of(9, minute);
+
+        // then
+        VacationLocalDateTime.of(localDate, localTime);
+    }
+
+    @DisplayName("10분 단위로 설정 가능 - 실패")
+    @ParameterizedTest
+    @ValueSource(ints = {1, 5, 9, 11, 21, 29, 31, 59})
+    void of_minute_fail(int minute) {
+        // given
+        LocalTime localTime = LocalTime.of(9, minute);
+
+        // then
+        assertThatThrownBy(() -> VacationLocalDateTime.of(localDate, localTime))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("10분 단위로 설정 가능");
     }
 
     @DisplayName("시간 더하고 비교하기")

--- a/src/test/java/com/sixshop/sixspace/vacation/domain/VacationLocalDateTimeTest.java
+++ b/src/test/java/com/sixshop/sixspace/vacation/domain/VacationLocalDateTimeTest.java
@@ -1,0 +1,108 @@
+package com.sixshop.sixspace.vacation.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class VacationLocalDateTimeTest {
+
+    private static final LocalDate localDate = LocalDate.of(2021, 5, 22);
+    private static final LocalTime localTime = LocalTime.of(13, 0);
+
+    @DisplayName("주입 받은 LocalDateTime 과 동일한 시간을 관리")
+    @Test
+    void of() {
+        // given
+        LocalDateTime compare = LocalDateTime.of(localDate, localTime);
+
+        // when
+        VacationLocalDateTime target = VacationLocalDateTime.of(compare);
+
+        // then
+        assertThat(target.getTime())
+            .isEqualTo(compare);
+    }
+
+    @DisplayName("time 필드가 동일하면 같은 객체로 판단한다")
+    @Test
+    void of_diff_parameter_compare() {
+        // given
+        VacationLocalDateTime target1 = VacationLocalDateTime.of(localDate, localTime);
+        VacationLocalDateTime target2 = VacationLocalDateTime.of(localDate, localTime);
+        VacationLocalDateTime target3 = VacationLocalDateTime.of(LocalDateTime.of(localDate, localTime));
+
+        // then
+        assertThat(target1)
+            .isEqualTo(target2)
+            .isEqualTo(target3);
+    }
+
+    @DisplayName("시간 더하고 비교하기")
+    @Test
+    void plusHours() {
+        // given
+        LocalDateTime localDateTime = LocalDateTime.of(localDate, localTime);
+        LocalDateTime plus1 = localDateTime.plusHours(1);
+
+        // when
+        VacationLocalDateTime target1 = VacationLocalDateTime.of(plus1);
+        VacationLocalDateTime target2 = VacationLocalDateTime.of(localDateTime).plusHours(1);
+
+        // then
+        assertThat(target1).isEqualTo(target2);
+        assertThat(target2.getTime()).isEqualTo(plus1);
+    }
+
+    @DisplayName("휴가 사용 시간이 퇴근 시간이 넘는 경우, 1시간 미만이 남으면 버린다")
+    @Test
+    void plusHours_remain_under_1hour() {
+        // given
+        LocalTime start = LocalTime.of(17, 30);
+        VacationLocalDateTime target = VacationLocalDateTime.of(localDate, start);
+
+        // when
+        target = target.plusHours(1);
+
+        // then
+        assertThat(target.getTime())
+            .isEqualTo(LocalDateTime.of(localDate, LocalTime.of(18, 0)));
+    }
+
+    @DisplayName("휴가 사용 시간이 퇴근 시간이 넘는 경우, 1시간 미만이 남으면 버린다")
+    @Test
+    void plusHours_remain_over_1hour() {
+        // given
+        LocalTime start = LocalTime.of(17, 30);
+        VacationLocalDateTime target = VacationLocalDateTime.of(localDate, start);
+
+        // when
+        target = target.plusHours(1);
+
+        // then
+        assertThat(target.getTime())
+            .isEqualTo(LocalDateTime.of(localDate, LocalTime.of(18, 0)));
+    }
+
+    @DisplayName("다음날로 넘어갈 경우 1시간 밑으로는 버리고 시간 추가")
+    @Test
+    void plusHours_remain_over_hour() {
+        // given
+        VacationLocalDateTime target1 = VacationLocalDateTime.of(localDate, LocalTime.of(17, 0));
+        VacationLocalDateTime target2 = VacationLocalDateTime.of(localDate, LocalTime.of(17, 30));
+        VacationLocalDateTime expect = VacationLocalDateTime.of(localDate.plusDays(1), LocalTime.of(11, 0));
+
+        // when
+        target1 = target1.plusHours(3);
+        target2 = target2.plusHours(3);
+
+        // then
+        assertThat(target1).isEqualTo(expect);
+        assertThat(target2).isEqualTo(expect);
+        assertThat(target1).isEqualTo(target2);
+    }
+
+}


### PR DESCRIPTION
심심해서 휴가 LocalDateTime wrapper 만들어봤어요 ㅎㅎ

* 기본 업무 시간 = 9 to 6
* 10분 단위로 휴가 시작 시간 세팅 가능
* 초 단위는 버림
* 1시간 단위로 휴가 사용 가능 -> 시간 더하기 기능 메서드만 제공
* `17:30`에 `1시간` 사용 할 경우 -> 남는 30분은 버림
* `17:30`에 `2시간` 사용 할 경우 -> 다음날 10시까지 휴가, (오늘 1시간 사용하고 남은 30분은 버림, 남은 1시간은 다음날 사용 처리)
* `17:00`에 `2시간` 사용 할 경우 -> 다음날 10시까지 휴가


ps. 
나중에 출퇴근 시간 조정도 가능하게 하려면 `GO_OFFICE_TIME`, `LEAVE_OFFICE_TIME` 필드 세팅 가능하게 하며 될듯해여